### PR TITLE
fix: allow user to upload latest app version

### DIFF
--- a/src/pages/UploadApk/UploadApk.js
+++ b/src/pages/UploadApk/UploadApk.js
@@ -49,7 +49,7 @@ export const UploadApk = ({ isOpen, handleClose, versionList, latest }) => {
     )
 
     const createdVersions = (
-        !isEmpty(versionList) ? versionList : [latest]
+        !isEmpty(versionList) ? versionList : []
     ).reduce((acc, v) => [...acc, v.version], [])
 
     const isGreaterLatestVersion = (e) => {

--- a/src/pages/UploadApk/UploadApk.js
+++ b/src/pages/UploadApk/UploadApk.js
@@ -48,9 +48,10 @@ export const UploadApk = ({ isOpen, handleClose, versionList }) => {
         ({ success }) => (success ? { success: true } : { critical: true })
     )
 
-    const createdVersions = (
-        !isEmpty(versionList) ? versionList : []
-    ).reduce((acc, v) => [...acc, v.version], [])
+    const createdVersions = (!isEmpty(versionList) ? versionList : []).reduce(
+        (acc, v) => [...acc, v.version],
+        []
+    )
 
     const isGreaterLatestVersion = (e) => {
         const latestVersion = createdVersions[0]

--- a/src/pages/UploadApk/UploadApk.js
+++ b/src/pages/UploadApk/UploadApk.js
@@ -32,7 +32,7 @@ const urlValidationMessage = i18n.t(
     'Please provide a valid URL that starts with http or https'
 )
 
-export const UploadApk = ({ isOpen, handleClose, versionList, latest }) => {
+export const UploadApk = ({ isOpen, handleClose, versionList }) => {
     const { mutateVersion, mutateList } = useUpdateVersions()
     const { show } = useAlert(
         ({ version, success }) =>

--- a/src/utils/validators/isValidVersion.js
+++ b/src/utils/validators/isValidVersion.js
@@ -1,6 +1,6 @@
 import semver from 'semver'
 
-export const versionRegex = /^\d+\.\d+(\.\d+)?$/
+export const versionRegex = /^\d+\.\d+(\.\d+)?(\.\d+)?$/
 
 export const isValidVersion = (version) => versionRegex.test(version)
 


### PR DESCRIPTION
Found during annual conference testing:
- When no versions exist, the UploadAPK dialog didn't allow the latest version number to be specified for a new upload
- The version regex only supported 3-part versions, but we sometimes have 4-part versions such as the latest 2.8.1.1