### PR TITLE
feat: erase all content [DHIS2-15911]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-05-23T15:08:23.082Z\n"
-"PO-Revision-Date: 2023-05-23T15:08:23.082Z\n"
+"POT-Creation-Date: 2023-10-09T19:20:00.151Z\n"
+"PO-Revision-Date: 2023-10-09T19:20:00.152Z\n"
 
 msgid ""
 "The initial configuration of the app has been completed and it is now ready "
@@ -102,6 +102,22 @@ msgstr "Android Capture app"
 
 msgid "All versions of the application"
 msgstr "All versions of the application"
+
+msgid "Erase all settings"
+msgstr "Erase all settings"
+
+msgid ""
+"This action will remove all APKs and configurations. Are you sure you want "
+"to erase all content and settings?"
+msgstr ""
+"This action will remove all APKs and configurations. Are you sure you want "
+"to erase all content and settings?"
+
+msgid "Erase"
+msgstr "Erase"
+
+msgid "Erase Settings"
+msgstr "Erase Settings"
 
 msgid "Description"
 msgstr "Description"

--- a/src/pages/ApkList/ApkList.js
+++ b/src/pages/ApkList/ApkList.js
@@ -8,6 +8,7 @@ import { useIsAuthorized } from '../../auth'
 import { VersionList } from '../../components'
 import { useDataStore, useLatestRelease } from '../../hooks'
 import styles from './ApkList.module.css'
+import { ResetValues } from './ResetValues/ResetValues'
 import { AboutSection, HeaderContent } from './Sections'
 
 export const ApkList = () => {
@@ -71,6 +72,8 @@ export const ApkList = () => {
                             )}
                         </>
                     )}
+
+                    <ResetValues disabled={!hasAuthority} />
                 </div>
             )}
         </Card>

--- a/src/pages/ApkList/ResetValues/DialogResetValues.js
+++ b/src/pages/ApkList/ResetValues/DialogResetValues.js
@@ -1,0 +1,40 @@
+import i18n from '@dhis2/d2-i18n'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    Button,
+    ButtonStrip,
+} from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export const DialogResetValues = ({ openDialog, onClose, deleteNamespace }) => (
+    <>
+        {openDialog && (
+            <Modal small position="middle" onClose={onClose}>
+                <ModalTitle>{i18n.t('Erase all settings')}</ModalTitle>
+                <ModalContent>
+                    {i18n.t(
+                        'This action will remove all APKs and configurations. Are you sure you want to erase all content and settings?'
+                    )}
+                </ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button onClick={onClose}>{i18n.t('Cancel')}</Button>
+                        <Button onClick={deleteNamespace} destructive>
+                            {i18n.t('Erase')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
+        )}
+    </>
+)
+
+DialogResetValues.propTypes = {
+    deleteNamespace: PropTypes.func.isRequired,
+    openDialog: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+}

--- a/src/pages/ApkList/ResetValues/ResetValues.js
+++ b/src/pages/ApkList/ResetValues/ResetValues.js
@@ -1,0 +1,50 @@
+import { useDataMutation } from '@dhis2/app-runtime'
+import i18n from '@dhis2/d2-i18n'
+import { Button } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import { NAMESPACE } from '../../../shared'
+import { DialogResetValues } from './DialogResetValues'
+import styles from './ResetValues.module.css'
+
+const deleteDataStoreMutation = {
+    resource: `dataStore/${NAMESPACE}`,
+    type: 'delete',
+}
+
+export const ResetValues = ({ disabled }) => {
+    const [mutate] = useDataMutation(deleteDataStoreMutation)
+    const [openDialog, setOpenDialog] = useState(false)
+
+    const onClose = () => {
+        setOpenDialog(false)
+    }
+
+    const deleteNamespaceDatastore = async () => {
+        onClose()
+        await mutate()
+        location.reload()
+    }
+
+    return (
+        <section className={styles.section}>
+            <Button
+                onClick={() => setOpenDialog(true)}
+                disabled={disabled}
+                destructive
+            >
+                {i18n.t('Erase Settings')}
+            </Button>
+
+            <DialogResetValues
+                onClose={onClose}
+                deleteNamespace={deleteNamespaceDatastore}
+                openDialog={openDialog}
+            />
+        </section>
+    )
+}
+
+ResetValues.propTypes = {
+    disabled: PropTypes.bool.isRequired,
+}

--- a/src/pages/ApkList/ResetValues/ResetValues.module.css
+++ b/src/pages/ApkList/ResetValues/ResetValues.module.css
@@ -1,0 +1,3 @@
+.section {
+    padding: var(--spacers-dp48) var(--spacers-dp12) var(--spacers-dp24);
+}

--- a/src/pages/ApkList/ResetValues/index.js
+++ b/src/pages/ApkList/ResetValues/index.js
@@ -1,0 +1,1 @@
+export * from './DialogResetValues'


### PR DESCRIPTION
**Implements** [DHIS2-15911](https://dhis2.atlassian.net/browse/DHIS2-15911)

---

### Key features

1. _Erase all content and settings_

---

### Description

Create a button that will erase all content and settings by deleting the namespace from `Datastore`

---

### Screenshots

_Button user with auth_
![image](https://github.com/dhis2/apk-distribution-app/assets/29384664/4bffae6a-1876-4f36-9556-8dfe6660c3eb)

_Erase settings modal_
![image](https://github.com/dhis2/apk-distribution-app/assets/29384664/bf9b6d36-79ec-46af-8c3f-052a55a02f99)

_Button user with no auth_
![image](https://github.com/dhis2/apk-distribution-app/assets/29384664/bcc668eb-12cd-46be-b7a0-54bf2c88e563)


[DHIS2-15911]: https://dhis2.atlassian.net/browse/DHIS2-15911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ