### PR TITLE
feat: save user group on the fly when editing version [DHIS2-17222]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-04-27T18:11:06.223Z\n"
-"PO-Revision-Date: 2024-04-27T18:11:06.223Z\n"
+"POT-Creation-Date: 2024-04-29T16:28:42.253Z\n"
+"PO-Revision-Date: 2024-04-29T16:28:42.253Z\n"
 
 msgid ""
 "The initial configuration of the app has been completed and it is now ready "
@@ -91,11 +91,8 @@ msgstr "Access"
 msgid "User Group access"
 msgstr "User Group access"
 
-msgid "Cancel"
-msgstr "Cancel"
-
-msgid "Save"
-msgstr "Save"
+msgid "Close"
+msgstr "Close"
 
 msgid "The version {{version}} has been successfully deleted."
 msgstr "The version {{version}} has been successfully deleted."
@@ -111,6 +108,9 @@ msgstr "Deleting an app version cannot be undone."
 
 msgid "Are you sure you want to delete app version {{version}}?"
 msgstr "Are you sure you want to delete app version {{version}}?"
+
+msgid "Cancel"
+msgstr "Cancel"
 
 msgid "Default"
 msgstr "Default"

--- a/src/components/UserGroupAccess/UserGroupAccess.js
+++ b/src/components/UserGroupAccess/UserGroupAccess.js
@@ -3,14 +3,27 @@ import React from 'react'
 import { AccessAdd } from './AccessAdd'
 import { AccessList } from './AccessList'
 
-export const UserGroupAccess = ({ groups, onChange, hasTitle }) => {
+export const UserGroupAccess = ({
+    groups,
+    onChange,
+    onSave,
+    edit,
+    hasTitle,
+}) => {
     const onAdd = ({ id: newId, name }) => {
-        onChange([...groups, { id: newId, name }])
+        const updatedGroups = [...groups, { id: newId, name }]
+        onChange(updatedGroups)
+        if (edit) {
+            onSave(updatedGroups)
+        }
     }
 
     const onRemove = ({ id: removedId }) => {
         const updatedList = groups.filter((e) => e.id !== removedId)
         onChange([...updatedList])
+        if (edit) {
+            onSave(updatedList)
+        }
     }
 
     return (
@@ -26,6 +39,7 @@ export const UserGroupAccess = ({ groups, onChange, hasTitle }) => {
 }
 
 UserGroupAccess.propTypes = {
+    edit: PropTypes.bool,
     groups: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string.isRequired,
@@ -34,4 +48,5 @@ UserGroupAccess.propTypes = {
     ),
     hasTitle: PropTypes.bool,
     onChange: PropTypes.func,
+    onSave: PropTypes.func,
 }

--- a/src/components/VersionList/AssignUserGroup.js
+++ b/src/components/VersionList/AssignUserGroup.js
@@ -44,8 +44,8 @@ export const AssignUserGroup = ({ version, versionList, handleList }) => {
         setGroups([])
     }
 
-    const handleSave = () => {
-        const updatedList = updateList(versionList, version, groups)
+    const handleSave = (currentGroups) => {
+        const updatedList = updateList(versionList, version, currentGroups)
 
         const updatePromises = [
             mutateList({
@@ -56,7 +56,6 @@ export const AssignUserGroup = ({ version, versionList, handleList }) => {
         Promise.all(updatePromises)
             .then(() => {
                 handleList(prepareAPKListTable(updatedList, userGroups))
-                handleClose()
                 show({ version: version, success: true })
             })
             .catch(() => show({ version: version, success: false }))
@@ -93,14 +92,13 @@ const AssignModal = ({ onHandleClose, onHandleSave, groups, handleGroups }) => (
                 groups={groups || []}
                 onChange={handleGroups}
                 hasTitle={!isEmpty(groups)}
+                edit={true}
+                onSave={onHandleSave}
             />
         </ModalContent>
         <ModalActions>
             <ButtonStrip end>
-                <Button onClick={onHandleClose}>{i18n.t('Cancel')}</Button>
-                <Button onClick={onHandleSave} primary>
-                    {i18n.t('Save')}
-                </Button>
+                <Button onClick={onHandleClose}>{i18n.t('Close')}</Button>
             </ButtonStrip>
         </ModalActions>
     </Modal>


### PR DESCRIPTION
**Implements** [DHIS2-17222](https://dhis2.atlassian.net/browse/DHIS2-17222)

---

### Key features

1. Only one button in Access (edit user group access) dialog.
2. Save user group on the fly when adding access. 
3. Save user group on the fly when removing access.

---

### Description

Access dialog should only have one button: `Close`. When adding or removing a user group this value should be saved in the datastore after clicking the button `Give access` or `Remove access`.

---

### Screenshots

_Empty user group list dialog_
![image](https://github.com/dhis2/apk-distribution-app/assets/29384664/000e0faf-7962-4e2b-8298-178b90fd0b89)

_User group list dialog_
![image](https://github.com/dhis2/apk-distribution-app/assets/29384664/4631c884-2713-4053-afef-b8c96b84c150)

[DHIS2-17222]: https://dhis2.atlassian.net/browse/DHIS2-17222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ