### PR TITLE
fix: download button with only userGroup [DHIS2-18400]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-10-18T10:56:30.081Z\n"
-"PO-Revision-Date: 2024-10-18T10:56:30.081Z\n"
+"POT-Creation-Date: 2024-11-16T18:13:40.652Z\n"
+"PO-Revision-Date: 2024-11-16T18:13:40.652Z\n"
 
 msgid ""
 "The initial configuration of the app has been completed and it is now ready "
@@ -85,6 +85,15 @@ msgstr "Android Capture app"
 msgid "All versions of the application"
 msgstr "All versions of the application"
 
+msgid "Latest version {{version}}"
+msgstr "Latest version {{version}}"
+
+msgid "Download Restricted"
+msgstr "Download Restricted"
+
+msgid "No version available. Please contact your administrator"
+msgstr "No version available. Please contact your administrator"
+
 msgid "Erase all settings"
 msgstr "Erase all settings"
 
@@ -128,9 +137,6 @@ msgstr ""
 "This app is fully functional offline enabling health workers in areas where "
 "there is limited or no Internet connection, continue with their regular "
 "work."
-
-msgid "Latest version {{version}}"
-msgstr "Latest version {{version}}"
 
 msgid "The version {{version}} has been successfully updated."
 msgstr "The version {{version}} has been successfully updated."

--- a/src/app-context/AppContext.js
+++ b/src/app-context/AppContext.js
@@ -3,6 +3,7 @@ import { createContext } from 'react'
 const AppContext = createContext({
     authorities: [],
     username: '',
+    userGroups: [],
     dataStore: [],
 })
 

--- a/src/app-context/AppProvider.js
+++ b/src/app-context/AppProvider.js
@@ -8,7 +8,7 @@ const query = {
     me: {
         resource: 'me',
         params: {
-            fields: ['authorities', 'username'],
+            fields: ['authorities', 'username', 'userGroups'],
         },
     },
     dataStore: {
@@ -35,11 +35,12 @@ const AppProvider = ({ children }) => {
         throw error
     }
 
-    const { authorities, username } = data.me
+    const { authorities, username, userGroups } = data.me
     const dataStore = data.dataStore
     const providerValue = {
         authorities,
         username,
+        userGroups,
         dataStore,
     }
 

--- a/src/pages/ApkList/ApkList.module.css
+++ b/src/pages/ApkList/ApkList.module.css
@@ -48,3 +48,8 @@
 .container {
     padding: 0 var(--spacers-dp24) var(--spacers-dp24);
 }
+
+.notice {
+    margin-inline-start: var(--spacers-dp12);
+    margin-inline-end: var(--spacers-dp12);
+}

--- a/src/pages/ApkList/LatestDownloadButton.js
+++ b/src/pages/ApkList/LatestDownloadButton.js
@@ -1,34 +1,30 @@
-import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
+import { useAppContext } from '../../app-context'
 import { DownloadButton } from '../../components'
 import styles from './ApkList.module.css'
 import { getLatestDownloadApk } from './helper'
 
-const query = {
-    me: {
-        resource: 'me',
-    },
-}
-
 export const LatestDownloadButton = ({ apkList }) => {
-    const { data, loading } = useDataQuery(query)
+    const { userGroups } = useAppContext()
     const [latest, setLatest] = useState({})
+    const [showButton, setShowButton] = useState(false)
 
     useEffect(() => {
-        if (data?.me) {
-            const { url, version } = getLatestDownloadApk(
+        if (userGroups) {
+            const { url, version, isInitialDefault } = getLatestDownloadApk(
                 apkList,
-                data.me.userGroups
+                userGroups
             )
             setLatest({ url, version })
+            setShowButton(isInitialDefault)
         }
-    }, [data, apkList])
+    }, [userGroups, apkList])
 
     return (
         <div>
-            {!loading && (
+            {showButton && (
                 <>
                     <DownloadButton url={latest.url} primary small={false} />
 

--- a/src/pages/ApkList/ListView.js
+++ b/src/pages/ApkList/ListView.js
@@ -1,0 +1,42 @@
+import i18n from '@dhis2/d2-i18n'
+import { CircularLoader, NoticeBox } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styles from './ApkList.module.css'
+
+export const ListView = ({
+    loading,
+    hasAuthority,
+    isInitialDefault,
+    children,
+}) => {
+    if (loading) {
+        return <CircularLoader />
+    }
+
+    if (!hasAuthority && !isInitialDefault) {
+        return (
+            <NoticeBox
+                title={i18n.t('Download Restricted')}
+                className={styles.notice}
+            >
+                {i18n.t(
+                    'No version available. Please contact your administrator'
+                )}
+            </NoticeBox>
+        )
+    }
+
+    if (!hasAuthority && isInitialDefault) {
+        return null
+    }
+
+    return children
+}
+
+ListView.propTypes = {
+    children: PropTypes.node,
+    hasAuthority: PropTypes.bool,
+    isInitialDefault: PropTypes.bool,
+    loading: PropTypes.bool,
+}

--- a/src/pages/ApkList/helper.js
+++ b/src/pages/ApkList/helper.js
@@ -72,16 +72,24 @@ export const getLatestDownloadApk = (apkList, userGroups) => {
 
     if (
         !isEmpty(apkBasedOnUser) &&
-        isGreaterVersion(apkBasedOnUser.version, apkDefault.version)
+        isGreaterVersion(apkBasedOnUser?.version, apkDefault?.version)
     ) {
         return {
-            version: apkBasedOnUser.version,
-            url: apkBasedOnUser.downloadURL,
+            version: apkBasedOnUser?.version,
+            url: apkBasedOnUser?.downloadURL,
+            isInitialDefault: true,
+        }
+    }
+
+    if (isEmpty(apkBasedOnUser) && !isEmpty(apkList) && isEmpty(apkDefault)) {
+        return {
+            isInitialDefault: false,
         }
     }
 
     return {
-        version: apkDefault.version,
-        url: apkDefault.downloadURL,
+        version: apkDefault?.version,
+        url: apkDefault?.downloadURL,
+        isInitialDefault: true,
     }
 }


### PR DESCRIPTION
**Implements** [DHIS2-18400](https://dhis2.atlassian.net/browse/DHIS2-18400)

---

### Key features

1. _Check  "latest" download button based on the userGroups of the current user (who is logged in)_
2. _Inform user about download restrictions_

---

### Description

- Allow admin to upload the first APK version with userGroups.
- If user has no admin authorities only show the download button if user has access.
- Inform user about download restrictions, if user has no access.


---

### Screenshots

_User with no access_
![image](https://github.com/user-attachments/assets/bb0d6836-96b5-47d6-8369-e30a3b33ddcb)

_User with access_
![image](https://github.com/user-attachments/assets/a304758e-21f8-48da-87aa-fcd159c7ba1f)

_Admin user_
![image](https://github.com/user-attachments/assets/e010e940-ba8d-4498-91af-73c294ac2d20)

_Admin with no apk version_
![image](https://github.com/user-attachments/assets/2852c0e6-a180-4017-92b5-f1a17cb75ac6)

_User with no apk version_
![image](https://github.com/user-attachments/assets/c92aa93a-9ae7-48c7-af7c-e0e44aa5f197)


[DHIS2-18400]: https://dhis2.atlassian.net/browse/DHIS2-18400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ